### PR TITLE
Allow using element inside modifier

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ export default postcss.plugin(
     const VALID_CHILDREN = {
       [BLOCK]: [ ELEMENT, MODIFIER ],
       [ELEMENT]: [ MODIFIER ],
-      [MODIFIER]: [ ELEMENT ]
+      [MODIFIER]: [ ELEMENT, MODIFIER ]
     };
 
     function recursiveWalker(container, previousSelector, parent, options, result, BLOCK_SELECTOR) {

--- a/src/index.js
+++ b/src/index.js
@@ -34,10 +34,10 @@ export default postcss.plugin(
     const VALID_CHILDREN = {
       [BLOCK]: [ ELEMENT, MODIFIER ],
       [ELEMENT]: [ MODIFIER ],
-      [MODIFIER]: []
+      [MODIFIER]: [ ELEMENT ]
     };
 
-    function recursiveWalker(container, previousSelector, parent, options, result) {
+    function recursiveWalker(container, previousSelector, parent, options, result, BLOCK_SELECTOR) {
       return function(node) {
         if (node.parent !== parent) return;
         if (VALID_RULES.indexOf(node.name) === -1) return;
@@ -50,7 +50,7 @@ export default postcss.plugin(
           return;
         }
 
-        const SELECTOR = prependAonB(previousSelector, generateSelector(node, ELEMENT, MODIFIER, OPTIONS));
+        const SELECTOR = prependAonB(previousSelector, generateSelector(node, ELEMENT, MODIFIER, OPTIONS, BLOCK_SELECTOR));
 
         container.append(
           new Rule({
@@ -60,7 +60,7 @@ export default postcss.plugin(
         );
 
         if (node.nodes.length) {
-          node.walkAtRules(recursiveWalker(container, SELECTOR, node, options, result))
+          node.walkAtRules(recursiveWalker(container, SELECTOR, node, options, result, BLOCK_SELECTOR))
         }
       }
     }
@@ -77,7 +77,7 @@ export default postcss.plugin(
           })
         );
 
-        blockAtRule.walkAtRules(recursiveWalker(CONTAINER, BLOCK_SELECTOR, blockAtRule, OPTIONS, result));
+        blockAtRule.walkAtRules(recursiveWalker(CONTAINER, BLOCK_SELECTOR, blockAtRule, OPTIONS, result, BLOCK_SELECTOR));
         blockAtRule.replaceWith(cleanChildren(CONTAINER, VALID_RULES));
       });
     };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -29,8 +29,13 @@ function getPrefix(type, ELEMENT, MODIFIER, OPTIONS) {
   }
 }
 
-function generateSelector({ name, params }, ELEMENT, MODIFIER, OPTIONS) {
-  const prefix = getPrefix(name, ELEMENT, MODIFIER, OPTIONS);
+function generateSelector({ name, parent, params }, ELEMENT, MODIFIER, OPTIONS, BLOCK_SELECTOR) {
+  let prefix = getPrefix(name, ELEMENT, MODIFIER, OPTIONS);
+
+  /* If using an element inside a modifier, apply the modifier to the block selector. */
+  if (name === 'e' && parent && parent.name === 'm') {
+    prefix = ` ${BLOCK_SELECTOR[0]}${prefix}`;
+  }
 
   return params.split(',').reduce((all, curr) => [].concat(all, `${prefix}${curr.trim()}`), []);
 }


### PR DESCRIPTION
In some backend systems, a modifier is applied to the block and not an element. In this case, it would be useful to be able to write:

```
@block foo {
  @modifier bar {
    @element baz {
      background: red;
    }
  }
}

```
To compile to:
```
.foo--bar .foo__baz {
  background: red;
}

```

The PR achieves this, but might be better as an option (apply modifier to block or element).